### PR TITLE
Fix cannot iterate over null errors

### DIFF
--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -60,13 +60,13 @@ slugify() {
 
 make_image_cmd() {
     DOCKERARGS=$(echo ${1} | jq -r .dockerargs)
-    VOLUMES=$(echo ${1} | jq -r '.volumes | map(" -v " + .) | join("")')
-    PORTS=$(echo ${1} | jq -r '.ports | map(" -p " + .) | join("")')
-    EXPOSE=$(echo ${1} | jq -r '.expose | map(" --expose " + .) | join("")')
+    VOLUMES=$(echo ${1} | jq -r '.volumes | select(. != null) | map(" -v " + .) | join("")')
+    PORTS=$(echo ${1} | jq -r '.ports | select(. != null) | map(" -p " + .) | join("")')
+    EXPOSE=$(echo ${1} | jq -r '.expose | select(. != null) | map(" --expose " + .) | join("")')
     # We'll add name in, if it exists
     NAME=$(echo ${1} | jq -r 'select(.name != null) | .name')
     NETWORK=$(echo ${1} | jq -r 'select(.network != null) | .network')
-    ENVIRONMENT=$(echo ${1} | jq -r '.environment | map(" -e " + .) | join("")')
+    ENVIRONMENT=$(echo ${1} | jq -r '.environment | select(. != null) | map(" -e " + .) | join("")')
     # echo ${1} | jq -r '.environment | join("\n")' > ${PWD}/${NAME}.env
     # ENVIRONMENT=" --env-file ${PWD}/${NAME}.env"
     if [ "${DOCKERARGS}" == "null" ]; then DOCKERARGS=; fi


### PR DESCRIPTION
Unless you specify empty arrays for these values in your config, the entry point script emits these errors while running:
`jq: error (at <stdin>:1): Cannot iterate over null (null)`

|Before|<img width="1313" alt="image" src="https://user-images.githubusercontent.com/2950214/155860254-888b2f92-a728-4739-92f2-975d4dac5458.png">|
|--|--|
|**After**|<img width="1319" alt="image" src="https://user-images.githubusercontent.com/2950214/155860264-77de405c-39cb-474a-885a-1c8934ef89c4.png">|

[Screenshots from jqplay](https://jqplay.org/s/CzPU5im0RE)